### PR TITLE
feat : 대회 참석 요청 승인 받을지 안받을지 체크하는 기능 추가 #97

### DIFF
--- a/hgu-oj-front/src/pages/ContestDetailPage.tsx
+++ b/hgu-oj-front/src/pages/ContestDetailPage.tsx
@@ -101,6 +101,7 @@ export const ContestDetailPage: React.FC = () => {
     contest,
     contestPhase,
     requiresPassword,
+    requiresApproval: contest?.requiresApproval ?? false,
     isAuthenticated,
     hasContestAdminOverride,
     onProtectedAccessGranted: () => protectedContentRef.current(),

--- a/hgu-oj-front/src/pages/LoginPage.tsx
+++ b/hgu-oj-front/src/pages/LoginPage.tsx
@@ -10,7 +10,7 @@ const LoginPage: React.FC = () => {
   const { login, isLoading, error, clearError, isAuthenticated } = useAuthStore();
 
   // Registration disabled flag
-  const registrationDisabled = false;
+  const registrationDisabled = true;
 
   const [formData, setFormData] = useState({
     username: '',

--- a/hgu-oj-front/src/pages/ProblemDetailPage.tsx
+++ b/hgu-oj-front/src/pages/ProblemDetailPage.tsx
@@ -1284,15 +1284,10 @@ export const ProblemDetailPage: React.FC = () => {
       {contestContextId && contestMeta && (
         <div className={`border-b px-4 py-3 text-xs sm:text-sm ${isDarkTheme ? 'border-slate-700 bg-slate-900 text-slate-200' : 'border-slate-200 bg-white text-slate-600'}`}>
           <div className="mx-auto flex max-w-7xl flex-col gap-3 lg:flex-row lg:items-center lg:justify-between lg:gap-6">
-            <div className="flex items-center gap-5">
-              <button
-                type="button"
-                onClick={() => navigate('/')}
-                className={`-ml-12 text-lg font-semibold tracking-tight transition ${isDarkTheme ? 'text-blue-200 hover:text-blue-300' : 'text-blue-700 hover:text-blue-800'}`}
-              >
-                HGU Online Judge
-              </button>
-              <span className={`text-lg font-semibold ${isDarkTheme ? 'text-slate-100' : 'text-slate-900'}`}>{contestMeta.title}</span>
+            <div className="flex items-center gap-3">
+              <span className={`text-lg font-semibold ${isDarkTheme ? 'text-slate-100' : 'text-slate-900'}`}>
+                {contestMeta.title}
+              </span>
             </div>
             <div className="flex flex-1 flex-wrap items-end justify-center gap-6 text-right">
               <div className="flex flex-col items-start">

--- a/hgu-oj-front/src/pages/RegisterPage.tsx
+++ b/hgu-oj-front/src/pages/RegisterPage.tsx
@@ -9,7 +9,7 @@ const RegisterPage: React.FC = () => {
   const { isAuthenticated } = useAuthStore();
 
   // Registration disabled flag
-  const registrationDisabled = false;
+  const registrationDisabled = true;
 
   const [formData, setFormData] = useState({
     username: '',

--- a/hgu-oj-front/src/services/adminService.ts
+++ b/hgu-oj-front/src/services/adminService.ts
@@ -116,6 +116,7 @@ export interface CreateContestPayload {
   visible: boolean;
   real_time_rank: boolean;
   allowed_ip_ranges: string[];
+  requires_approval?: boolean;
 }
 
 export interface CreateWorkbookPayload {
@@ -173,6 +174,7 @@ export interface UpdateContestPayload {
   visible: boolean;
   real_time_rank: boolean;
   allowed_ip_ranges: string[];
+  requires_approval?: boolean;
 }
 
 interface ContestProblemListPayload {

--- a/hgu-oj-front/src/services/contestService.ts
+++ b/hgu-oj-front/src/services/contestService.ts
@@ -137,6 +137,7 @@ const mapContest = (raw: any): Contest => ({
   contestType: raw.contest_type ?? raw.contestType,
   realTimeRank: raw.real_time_rank ?? raw.realTimeRank,
   now: raw.now,
+  requiresApproval: raw.requires_approval ?? raw.requiresApproval,
   problemCount: (() => {
     const candidates = [
       raw.problem_count,

--- a/hgu-oj-front/src/services/contestUserService.ts
+++ b/hgu-oj-front/src/services/contestUserService.ts
@@ -34,6 +34,11 @@ type RawContestUserRegistrationList = {
   pending?: RawContestUserRegistration[];
 };
 
+export interface ContestApprovalPolicy {
+  contestId: number;
+  requiresApproval: boolean;
+}
+
 const CONTEST_USER_STATUS_VALUES: ContestUserStatusValue[] = ['approved', 'pending', 'rejected'];
 
 const normalizeContestUserStatusValue = (value?: string): ContestUserStatusValue | undefined => {
@@ -127,6 +132,31 @@ export const contestUserService = {
       },
       contestId,
     );
+  },
+  getPolicy: async (contestId: number): Promise<ContestApprovalPolicy> => {
+    if (!contestId) {
+      throw new Error('유효하지 않은 대회입니다.');
+    }
+    const response = await apiClient.get<any>(`${ensureBaseUrl()}/${contestId}/policy`);
+    const payload = response.data ?? {};
+    return {
+      contestId: Number(payload.contest_id ?? payload.contestId ?? contestId),
+      requiresApproval: Boolean(payload.requires_approval ?? payload.requiresApproval),
+    };
+  },
+  setPolicy: async (contestId: number, requiresApproval: boolean): Promise<ContestApprovalPolicy> => {
+    if (!contestId) {
+      throw new Error('유효하지 않은 대회입니다.');
+    }
+    const response = await apiClient.post<any>(`${ensureBaseUrl()}/${contestId}/policy`, {
+      contest_id: contestId,
+      requires_approval: requiresApproval,
+    });
+    const payload = response.data ?? {};
+    return {
+      contestId: Number(payload.contest_id ?? payload.contestId ?? contestId),
+      requiresApproval: Boolean(payload.requires_approval ?? payload.requiresApproval),
+    };
   },
   getRegistrations: async (contestId: number): Promise<ContestUserRegistrationList> => {
     if (!contestId) {

--- a/hgu-oj-front/src/types/index.ts
+++ b/hgu-oj-front/src/types/index.ts
@@ -84,6 +84,7 @@ export interface Contest {
   realTimeRank?: boolean;
   now?: string;
   problemCount?: number;
+  requiresApproval?: boolean;
 }
 
 export interface ContestAnnouncement {
@@ -386,6 +387,7 @@ export interface AdminContest extends Contest {
   real_time_rank: boolean;
   allowed_ip_ranges: string[];
   status?: string;
+  requires_approval?: boolean;
 }
 
 export interface AdminContestListResponse {

--- a/micro-service-server/app/contest_user/repository.py
+++ b/micro-service-server/app/contest_user/repository.py
@@ -52,7 +52,7 @@ async def list_memberships(contest_id: int, db: AsyncSession) -> List[Tuple[Cont
     stmt = (
         select(ContestUser, User)
         .join(User, User.id == ContestUser.user_id)
-        .where(ContestUser.contest_id == contest_id)
+        .where(ContestUser.contest_id == contest_id, ContestUser.user_id > 0)
         .order_by(ContestUser.created_time.asc())
     )
     result = await db.execute(stmt)
@@ -84,6 +84,38 @@ async def update_membership_status(
     )
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
+
+
+async def upsert_policy(contest_id: int, requires_approval: bool, db: AsyncSession) -> ContestUser:
+    stmt = (
+        insert(ContestUser)
+        .values(
+            contest_id=contest_id,
+            user_id=0,
+            status="policy_requires" if requires_approval else "policy_auto",
+            approved_by=None,
+            approved_at=None,
+        )
+        .on_conflict_do_update(
+            index_elements=["contest_id", "user_id"],
+            set_={
+                ContestUser.status: "policy_requires" if requires_approval else "policy_auto",
+                ContestUser.updated_time: func.now(),
+            },
+        )
+        .returning(ContestUser)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one()
+
+
+async def get_policy(contest_id: int, db: AsyncSession) -> bool:
+    stmt = select(ContestUser.status).where(ContestUser.contest_id == contest_id, ContestUser.user_id == 0)
+    result = await db.execute(stmt)
+    status = result.scalar_one_or_none()
+    if status is None:
+        return True
+    return status == "policy_requires"
 
 
 async def get_contest_by_id(contest_id: int, db: AsyncSession) -> Optional[Contest]:

--- a/micro-service-server/app/contest_user/routes.py
+++ b/micro-service-server/app/contest_user/routes.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config.database import get_session
 from app.contest_user.schemas import (
+    ContestApprovalPolicy,
     ContestUserDecisionRequest,
     ContestUserJoinRequest,
     ContestUserListResponse,
@@ -51,3 +52,21 @@ async def decide_contest_user(
     db: AsyncSession = Depends(get_session),
 ):
     return await contest_user_service.decide_contest_user(contest_id, payload, userdata, db)
+
+
+@router.get("/{contest_id}/policy", response_model=ContestApprovalPolicy)
+async def get_contest_policy(
+    contest_id: int,
+    db: AsyncSession = Depends(get_session),
+):
+    return await contest_user_service.get_approval_policy(contest_id, db)
+
+
+@router.post("/{contest_id}/policy", response_model=ContestApprovalPolicy)
+async def set_contest_policy(
+    contest_id: int,
+    payload: ContestApprovalPolicy,
+    userdata: UserData = Depends(get_userdata),
+    db: AsyncSession = Depends(get_session),
+):
+    return await contest_user_service.set_approval_policy(contest_id, payload.requires_approval, userdata, db)

--- a/micro-service-server/app/contest_user/schemas.py
+++ b/micro-service-server/app/contest_user/schemas.py
@@ -20,6 +20,11 @@ class ContestUserStatus(BaseModel):
     requires_approval: bool = False
 
 
+class ContestApprovalPolicy(BaseModel):
+    contest_id: int
+    requires_approval: bool
+
+
 class ContestUserDetail(BaseModel):
     user_id: int
     username: str | None = None

--- a/micro-service-server/app/contest_user/service.py
+++ b/micro-service-server/app/contest_user/service.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.contest_user import repository as contest_user_repository
 from app.contest_user.models import ContestUser
 from app.contest_user.schemas import (
+    ContestApprovalPolicy,
     ContestUserDecisionRequest,
     ContestUserDetail,
     ContestUserListResponse,
@@ -52,14 +53,21 @@ async def join_contest(contest_id: int, userdata: UserData, db: AsyncSession) ->
     if _has_contest_ended(contest.end_time):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="종료된 대회에는 참여할 수 없습니다.")
 
+    requires_approval_policy = await contest_user_repository.get_policy(contest_id, db)
     status: ParticipationStatus = APPROVED
     approver = userdata.user_id if is_admin_user else None
 
-    if not is_admin_user and _has_contest_started(contest.start_time):
+    if not is_admin_user and requires_approval_policy and _has_contest_started(contest.start_time):
         status = PENDING
 
     membership = await contest_user_repository.upsert_membership(contest_id, userdata.user_id, status, approver, db)
-    return _build_status(contest_id, userdata, membership, is_admin=is_admin_user)
+    return _build_status(
+        contest_id,
+        userdata,
+        membership,
+        is_admin=is_admin_user,
+        requires_approval=requires_approval_policy,
+    )
 
 
 @transactional
@@ -69,6 +77,7 @@ async def get_membership_status(contest_id: int, userdata: UserData, db: AsyncSe
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
     is_admin_user = _is_admin(userdata)
+    requires_approval_policy = await contest_user_repository.get_policy(contest_id, db)
     if is_admin_user:
         return ContestUserStatus(
             contest_id=contest_id,
@@ -81,7 +90,13 @@ async def get_membership_status(contest_id: int, userdata: UserData, db: AsyncSe
         )
 
     membership = await contest_user_repository.find_by_contest_and_user(contest_id, userdata.user_id, db)
-    return _build_status(contest_id, userdata, membership, is_admin=False)
+    return _build_status(
+        contest_id,
+        userdata,
+        membership,
+        is_admin=False,
+        requires_approval=requires_approval_policy,
+    )
 
 
 @transactional
@@ -172,11 +187,12 @@ def _build_status(
     membership: ContestUser | None,
     *,
     is_admin: bool,
+    requires_approval: bool,
 ) -> ContestUserStatus:
     status = membership.status if membership else (APPROVED if is_admin else None)
     joined = (status == APPROVED) or is_admin
     joined_at = membership.created_time if membership else None
-    requires_approval = status == PENDING
+    requires_approval_flag = requires_approval and status == PENDING
     return ContestUserStatus(
         contest_id=contest_id,
         user_id=userdata.user_id,
@@ -184,8 +200,22 @@ def _build_status(
         joined_at=joined_at,
         is_admin=is_admin,
         status=status,
-        requires_approval=requires_approval,
+        requires_approval=requires_approval_flag,
     )
+
+
+@transactional
+async def set_approval_policy(contest_id: int, requires_approval: bool, userdata: UserData, db: AsyncSession) -> ContestApprovalPolicy:
+    _ensure_valid_contest_id(contest_id)
+    _ensure_admin(userdata)
+    await contest_user_repository.upsert_policy(contest_id, requires_approval, db)
+    return ContestApprovalPolicy(contest_id=contest_id, requires_approval=requires_approval)
+
+
+async def get_approval_policy(contest_id: int, db: AsyncSession) -> ContestApprovalPolicy:
+    _ensure_valid_contest_id(contest_id)
+    requires = await contest_user_repository.get_policy(contest_id, db)
+    return ContestApprovalPolicy(contest_id=contest_id, requires_approval=requires)
 
 
 def _ensure_admin(userdata: UserData) -> None:


### PR DESCRIPTION
## #️⃣연관된 이슈

#97

- 대회 참석 요청 승인 받을지 안받을지 체크하는 기능 추가
- 대회 문제풀이 상단 헤더에 로고 삭제
- 회원가입 그거 flag true 로 바꿈